### PR TITLE
fixed typo & added Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.zip
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+plugin=CommentOnly
+version=0.0.2
+all:
+	@ echo "Build archive for plugin ${plugin} version=${version}"
+	@ git archive HEAD --prefix=${plugin}/ --format=zip -o ${plugin}-${version}.zip

--- a/Plugin.php
+++ b/Plugin.php
@@ -18,7 +18,7 @@ class Plugin extends Base
   }
   public function getPluginName()
   {
-    return 'Comment Only Resctrictions for Project Viewers';
+    return 'Comment Only Restrictions for Project Viewers';
   }
   public function getPluginAuthor()
   {
@@ -26,12 +26,12 @@ class Plugin extends Base
   }
   public function getPluginVersion()
   {
-    return '0.0.1';
+    return '0.0.2';
   }
   
   public function getPluginDescription()
   {
-    return 'Add Commenting abilities for Project Viewers';
+    return 'Adds Commenting abilities for Project Viewers';
   }
   public function getPluginHomepage()
   {


### PR DESCRIPTION
### All Submissions:
* [x] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?

### New Feature Submissions:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Description
The typos were bugging me.
You'll need to do a new release.
`make` Use Makefile to generate zip
`git tag 0.0.2 -m "CommentOnly"` create a new tag
`git push origin --tags` push the new tag
Then go to https://github.com/creecros/opencomment/releases edit the latest release to add any notes & attach/upload the CommentOnly-0.0.2.zip to the release
Copy the link and then update https://github.com/kanboard/website/blob/master/plugins.json with a new link, version, updated title & description.

Changes proposed in this pull request:
- Fix title & description
- Added Makefile & gitignore
